### PR TITLE
Fixed forgottern changelog tag from previous release

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.1.0]
 
 ### Added
 


### PR DESCRIPTION
# What this PR does?

- Fixes CHANGELOG tag from previous release

## - Before/After

- Last release was merged into `master` branch without bumping release notes' version

## - How to test it?

- No tests are required

## - TODOs

None

## - Risks

None
