### PR TITLE
Fix lifecyle of registered components

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
--   In order to use scoped-per-request registered modules, controllers must access scoped components through `ctx.state.container.resolve('moduleName')` instead of receiving them from module injection. Not that I agree that much, but that's how it was built to work :/
+-   In order to use scoped-per-request registered modules, controllers must access scoped components through `ctx.state.container.resolve('moduleName')` instead of receiving them from module injection. That's how it was built to work :/
 
 ## [0.1.0]
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
--   In order to use scoped-per-request registered modules, controllers must access scoped components through `ctx.state.container.resolve('moduleName')` instead of receiving them from module injection. That's how it was built to work :/
+-   In order to use scoped-per-request registered modules, controllers must access scoped components through `ctx.state.container.resolve('moduleName')` instead of receiving them from module injection. That's how it was built to work.
 
 ## [0.1.0]
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [UNRELEASED]
+
+### Added
+
+-   ScopePerRequest middleware
+
+### Changed
+
+-   In order to use scoped-per-request registered modules, controllers must access scoped components through `ctx.state.container.resolve('moduleName')` instead of receiving them from module injection. Not that I agree that much, but that's how it was built to work :/
+
 ## [0.1.0]
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   "dependencies": {
     "@koa/cors": "^3.1.0",
     "awilix": "^4.2.6",
+    "awilix-koa": "^4.0.0",
     "dotenv": "^8.2.0",
     "http-status": "^1.4.2",
     "koa": "^2.13.0",

--- a/src/application/controllers/healthCheck.js
+++ b/src/application/controllers/healthCheck.js
@@ -2,11 +2,10 @@ const { OK, INTERNAL_SERVER_ERROR } = require('http-status');
 
 module.exports = () => {
     const healthCheck = async ctx => {
-
         const everythingIsOk = true;
 
-        const status = everythingIsOk? OK: INTERNAL_SERVER_ERROR;
-        const body = everythingIsOk? "OK": "KO";;
+        const status = everythingIsOk ? OK : INTERNAL_SERVER_ERROR;
+        const body = everythingIsOk ? "OK" : "KO";
 
         ctx.status = status;
         ctx.body = body

--- a/src/application/router.js
+++ b/src/application/router.js
@@ -1,6 +1,7 @@
 const Router = require('koa-router');
 
 module.exports = ({ healthCheckController }) => {
+
     const router = new Router();
 
     // Welcome

--- a/src/application/server.js
+++ b/src/application/server.js
@@ -2,22 +2,22 @@ const Koa = require('koa');
 const bodyParser = require('koa-bodyparser');
 const compress = require('koa-compress');
 const cors = require('@koa/cors');
-require('dotenv/config');
+
+const { scopePerRequest } = require('awilix-koa');
 
 const helmet = require('koa-helmet');
 
 const { inspect } = require('util');
 const { SERVER_PORT } = process.env;
 
-module.exports = ({ router, logger }) => {
-    
+module.exports = ({ router, logger, container }) => {
     const server = new Koa();
-    
     server
         .use(helmet())
         .use(compress())
         .use(cors())
         .use(bodyParser({ enableTypes: ['json'] }))
+        .use(scopePerRequest(container))
         .use(router.routes());
 
     return {

--- a/src/container.js
+++ b/src/container.js
@@ -1,4 +1,4 @@
-const { createContainer, asFunction } = require('awilix');
+const { createContainer, asFunction, asValue } = require('awilix');
 
 const loggerFactory = require('./infrastructure/logger/loggerFactory');
 
@@ -10,8 +10,9 @@ const healthCheckControllerFactory = require('./application/controllers/healthCh
 const container = createContainer();
 
 container.register({
+    container: asValue(container),
     logger: asFunction(loggerFactory).singleton(),
-    healthCheckController: asFunction(healthCheckControllerFactory).scoped(),
+    healthCheckController: asFunction(healthCheckControllerFactory).singleton(),
     server: asFunction(serverFactory).singleton(),
     router: asFunction(routerFactory).singleton()
 });

--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,5 @@
+require('dotenv/config');
+
 const container = require('./container');
 
 const server = container.resolve('server');

--- a/yarn.lock
+++ b/yarn.lock
@@ -9,6 +9,18 @@
   dependencies:
     vary "^1.1.2"
 
+"@koa/router@^8.0.0":
+  version "8.0.8"
+  resolved "https://registry.yarnpkg.com/@koa/router/-/router-8.0.8.tgz#95f32d11373d03d89dcb63fabe9ac6f471095236"
+  integrity sha512-FnT93N4NUehnXr+juupDmG2yfi0JnWdCmNEuIXpCG4TtG+9xvtrLambBH3RclycopVUOEYAim2lydiNBI7IRVg==
+  dependencies:
+    debug "^4.1.1"
+    http-errors "^1.7.3"
+    koa-compose "^4.1.0"
+    methods "^1.1.2"
+    path-to-regexp "1.x"
+    urijs "^1.19.2"
+
 "@sindresorhus/is@^0.14.0":
   version "0.14.0"
   resolved "https://registry.yarnpkg.com/@sindresorhus/is/-/is-0.14.0.tgz#9fb3a3cf3132328151f353de4632e01e52102bea"
@@ -76,6 +88,23 @@ anymatch@~3.1.1:
   dependencies:
     normalize-path "^3.0.0"
     picomatch "^2.0.4"
+
+awilix-koa@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/awilix-koa/-/awilix-koa-4.0.0.tgz#6c1bbdaaa2f35f00a00274c92ec9217bb7dc0869"
+  integrity sha512-6VzIBRblP7Ratol3NfqhM3xBJLDo2h9eUzka6NO2GlIjBdTQlWBVLmIV8rWJXOo1D9YqgXxKd78clh7XwmFfPQ==
+  dependencies:
+    "@koa/router" "^8.0.0"
+    awilix-router-core "^1.6.1"
+    koa-compose "^4.1.0"
+
+awilix-router-core@^1.6.1:
+  version "1.6.1"
+  resolved "https://registry.yarnpkg.com/awilix-router-core/-/awilix-router-core-1.6.1.tgz#6d51e1e832bf1284901be6e5554129fbd715f2cf"
+  integrity sha512-Zs2YUSkV8v1PJ6dEp7td/OjQ81gjwsk/lBHMFCwZDpe17efJaz4WNsB97Y/X/FOQ7vQ3+c87+Nvh1HCmHxrhPQ==
+  dependencies:
+    glob "^7.1.3"
+    tslib "^1.9.3"
 
 awilix@^4.2.6:
   version "4.2.6"
@@ -481,7 +510,7 @@ glob-parent@~5.1.0:
   dependencies:
     is-glob "^4.0.1"
 
-glob@^7.1.6:
+glob@^7.1.3, glob@^7.1.6:
   version "7.1.6"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.6.tgz#141f33b81a7c2492e125594307480c46679278a6"
   integrity sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==
@@ -749,6 +778,11 @@ is-yarn-global@^0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/is-yarn-global/-/is-yarn-global-0.3.0.tgz#d502d3382590ea3004893746754c89139973e232"
   integrity sha512-VjSeb/lHmkoyd8ryPVIKvOCn4D1koMqY+vqyjjUfc3xyKtP4dYOxM44sZrnqQSzSds3xyOrUTLTC9LVCVgLngw==
+
+isarray@0.0.1:
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/isarray/-/isarray-0.0.1.tgz#8a18acfca9a8f4177e09abfc6038939b05d1eedf"
+  integrity sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=
 
 json-buffer@3.0.0:
   version "3.0.0"
@@ -1043,6 +1077,13 @@ path-is-absolute@^1.0.0:
   resolved "https://registry.yarnpkg.com/path-is-absolute/-/path-is-absolute-1.0.1.tgz#174b9268735534ffbc7ace6bf53a5a9e1b5c5f5f"
   integrity sha1-F0uSaHNVNP+8es5r9TpanhtcX18=
 
+path-to-regexp@1.x:
+  version "1.8.0"
+  resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-1.8.0.tgz#887b3ba9d84393e87a0a0b9f4cb756198b53548a"
+  integrity sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==
+  dependencies:
+    isarray "0.0.1"
+
 path-to-regexp@^6.1.0:
   version "6.1.0"
   resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-6.1.0.tgz#0b18f88b7a0ce0bfae6a25990c909ab86f512427"
@@ -1268,7 +1309,7 @@ touch@^3.1.0:
   dependencies:
     nopt "~1.0.10"
 
-tslib@^1.10.0:
+tslib@^1.10.0, tslib@^1.9.3:
   version "1.13.0"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.13.0.tgz#c881e13cc7015894ed914862d276436fa9a47043"
   integrity sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q==
@@ -1335,6 +1376,11 @@ update-notifier@^4.0.0:
     pupa "^2.0.1"
     semver-diff "^3.1.1"
     xdg-basedir "^4.0.0"
+
+urijs@^1.19.2:
+  version "1.19.2"
+  resolved "https://registry.yarnpkg.com/urijs/-/urijs-1.19.2.tgz#f9be09f00c4c5134b7cb3cf475c1dd394526265a"
+  integrity sha512-s/UIq9ap4JPZ7H1EB5ULo/aOUbWqfDi7FKzMC2Nz+0Si8GiT1rIEaprt8hy3Vy2Ex2aJPpOQv4P4DuOZ+K1c6w==
 
 url-parse-lax@^3.0.0:
   version "3.0.0"


### PR DESCRIPTION
# What this PR does?

- Added ScopePerRequest middleware

In order to use scoped-per-request registered modules, controllers must access scoped components through `ctx.state.container.resolve('moduleName')` instead of receiving them from module injection. That's how it was built to work 

## - Before/After

Controllers were scoped, but never rebuilt. That was misundestood on how exactly awilix scopes components into requests.

## - How to test it?

Controllers are singletons. And scoped components should be accessed through the instructions given above.

## - TODOs
- None

## - Risks
- None
